### PR TITLE
Liucija/temp move to init

### DIFF
--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -1,6 +1,18 @@
 from flask import Flask
 from app.views import main_blueprint
-from app.models import DATABASE_CONNECTION_URI, db
+from flask_sqlalchemy import SQLAlchemy
+import os
+
+
+user = os.environ["POSTGRES_USER"]
+password = os.environ["POSTGRES_PASSWORD"]
+host = "db"
+database = os.environ["POSTGRES_DB"]
+port = "5432"
+
+DATABASE_CONNECTION_URI = f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}"
+
+db = SQLAlchemy()
 
 
 def create_app():

--- a/server/app/database.py
+++ b/server/app/database.py
@@ -1,4 +1,4 @@
-from app.models import db
+from app import db
 
 
 def get_all(model):

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1,16 +1,4 @@
-import os
-
-from flask_sqlalchemy import SQLAlchemy
-
-user = os.environ["POSTGRES_USER"]
-password = os.environ["POSTGRES_PASSWORD"]
-host = "db"
-database = os.environ["POSTGRES_DB"]
-port = "5432"
-
-DATABASE_CONNECTION_URI = f"postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}"
-
-db = SQLAlchemy()
+from app import db
 
 
 class Users(db.Model):


### PR DESCRIPTION
Moving db object to init seems to have affected the paths and now cannot import db by using "from app import db" in database.py.

Changing to from app.__init__ seems to work for that scenario but then other improrts fail. 

Stack:
```
flask.cli.NoAppException: While importing "run", an ImportError was raised:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/cli.py", line 240, in locate_app
    __import__(module_name)
  File "/app/run.py", line 1, in <module>
    from app import create_app
  File "/app/app/__init__.py", line 2, in <module>
    from app.views import main_blueprint
  File "/app/app/views.py", line 4, in <module>
    from app import database
  File "/app/app/database.py", line 1, in <module>
    from app import db
ImportError: cannot import name 'db'
```