### PR TITLE
exception for blank image

### DIFF
--- a/server/predictor/cbir_predictor.py
+++ b/server/predictor/cbir_predictor.py
@@ -53,6 +53,8 @@ class CBIRPredictor:
         Obtains keypoints and their descriptors for an image
         """
         _, des = self.orb.detectAndCompute(img, None)
+        if des is None:
+            raise InvalidImageException()
         return des
 
     def calc_record_distances(self, des, routes_and_images, nmatches):


### PR DESCRIPTION
If an image is blank (i.e. no corners, edges etc.) then no keypoints will be detected and the server will throw an obscure error here:
```self.query_descriptor_json = json.dumps(des.tolist())```

This exception detects when there are no keypoints and raises an exception to prevent any further processing / matching. 

This seems very small and not worth testing? I have a draft test if you think it's important though