### PR TITLE
--tables arg for recreate-db command

### DIFF
--- a/server/app/commands.py
+++ b/server/app/commands.py
@@ -6,11 +6,14 @@ from scripts.dummy_db_data import preload_dummy_data
 
 
 @click.command("recreate-db")
+@click.option("--tables", type=str)
 @with_appcontext
-def recreate_db_cmd():
+def recreate_db_cmd(tables):
     db.drop_all()
     db.create_all()
     print("Initialised the database")
 
-    preload_dummy_data(db)
+    if tables is not None:
+        tables = tables.split(",")
+    preload_dummy_data(db, tables)
     print("Preloaded dummy data in the database")

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -23,7 +23,8 @@ case "$1" in
         /usr/bin/supervisord
     ;;
     recreate-db)
-        flask recreate-db
+        shift;
+        flask recreate-db "$@"
     ;;
     routes)
         flask routes

--- a/server/scripts/dummy_db_data.py
+++ b/server/scripts/dummy_db_data.py
@@ -1,15 +1,17 @@
 import pandas as pd
 
-from app.models import Gyms, RouteImages, Routes, UserRouteLog, Users
 from app.utils.encoding import json_to_nparraybytes
 
 
-def preload_dummy_data(db):
-    load_table(db, Users)
-    load_table(db, Gyms)
-    load_table(db, Routes)
-    load_table(db, RouteImages)
-    load_table(db, UserRouteLog)
+def preload_dummy_data(db, tables):
+    for cls in db.Model._decl_class_registry.values():
+        if not isinstance(cls, type) or not issubclass(cls, db.Model):
+            continue
+
+        if tables is not None and cls.__tablename__ not in tables:
+            continue
+
+        load_table(db, cls)
 
     db.session.commit()
 
@@ -22,6 +24,7 @@ def load_table(db, ModelClass):
 
 
     table_name = ModelClass.__tablename__
+    print(f"\tloading '{table_name}' table")
 
     table_df = pd.read_csv(f"resources/{table_name}.csv")
     table_df = table_df.where(pd.notnull(table_df), None)


### PR DESCRIPTION
This lets us to load dummy data for selected tables only. All tables would still be dropped, though!

example usage:
`make args='recreate-db --tables users,gyms' docker-run`